### PR TITLE
fix: key meta tags by property so og:* tags stop collapsing

### DIFF
--- a/__tests__/manager.tsx
+++ b/__tests__/manager.tsx
@@ -62,4 +62,30 @@ describe('Manager', () => {
       '<meta charset="UTF-8"><meta data-test="2" style="color: black;"><style>#test { color: red; }</style>',
     );
   });
+
+  it('should keep og:* meta tags distinct by property (regression: property collapse)', () => {
+    const manager = new Manager();
+
+    manager.isServer = true;
+
+    manager.pushTags(
+      <>
+        <meta property="og:title" content="Title A" />
+        <meta property="og:description" content="Desc B" />
+        <meta property="og:url" content="https://example.com/page" />
+        <meta property="og:image" content="https://example.com/img.png" />
+      </>,
+      containerId,
+    );
+
+    const { meta } = manager.getTags();
+    const htmlMeta = renderServerMeta(meta);
+    const ogCount = (htmlMeta.match(/property="og:/g) ?? []).length;
+
+    expect(ogCount).to.equal(4);
+    expect(htmlMeta).to.contain('property="og:title"');
+    expect(htmlMeta).to.contain('property="og:description"');
+    expect(htmlMeta).to.contain('property="og:url"');
+    expect(htmlMeta).to.contain('property="og:image"');
+  });
 });

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -194,7 +194,7 @@ class Manager {
     let key = '';
 
     // try to build unique key by unique props
-    for (const uniqueAttr of ['id', 'name', 'href', 'src']) {
+    for (const uniqueAttr of ['id', 'name', 'property', 'href', 'src']) {
       if (props[uniqueAttr]) {
         key = `[${uniqueAttr}='${props[uniqueAttr] as string}']`;
 


### PR DESCRIPTION
## Problem (live on prod, sitewide)

Every page on lomray.com renders only a single `og:image` Open Graph tag — `og:title`, `og:description`, `og:url`, `og:type`, `og:site_name`, `og:locale` are all missing, even though the app's `MetaData` component emits them. (Verified by raw curl on home, a blog article, and `/services/web-development` — all show 1× `og:image`, 0× every other `og:*`. The 4 `twitter:*` tags survive.)

## Root cause

`Manager.buildKeyByProps` only treats `['id', 'name', 'href', 'src']` as unique attributes. `twitter:*` tags use `name=` so each gets a distinct key and survives. `og:*` tags use `property=` — none of the unique attrs match, so they fall through to the prop-name fallback which builds the key from prop **names** (`[property][content]`), not values. Result: **every** `<meta property=… content=…>` collapses to the identical key `meta[property][content]`, last-write-wins — only the last og tag (`og:image`) survives.

## Fix

Add `property` to the unique-attr list so each `og:*` tag keeps a distinct key (`meta[property='og:title']`, etc). One line.

## Tests

Added a regression test asserting 4 distinct `og:*` tags survive. Proven red→green: on the unfixed code it fails `expected 1 to equal 4` (reproducing the prod symptom); with the fix the full suite is green (5/5). `ts:check`, eslint, and rollup build all clean.

Consumed by `lomray-website` at `@lomray/react-head-manager@^2.0.2`; after publish I'll bump the dep there.