### PR TITLE
fix: render root tag attributes without a document element on react 19

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -54,8 +54,14 @@ jobs:
       - name: Typescript check
         run: npm run ts:check
 
-      - name: Test
+      - name: Test (React 18)
         run: npm run test -- --coverage
+
+      - name: Install React 19
+        run: npm install --no-save --ignore-scripts react@19.2.8 react-dom@19.2.8
+
+      - name: Test (React 19)
+        run: npm test
 
       - uses: actions/upload-artifact@v4
         with:

--- a/__tests__/server/index.tsx
+++ b/__tests__/server/index.tsx
@@ -5,6 +5,8 @@ import { Manager } from '../../src';
 import ServerManager from '../../src/server';
 
 describe('ServerManager', () => {
+  const containerId = 'container-id';
+
   it('should inject meta tags into HTML string', () => {
     const htmlStr =
       '<html lang="en"><head><title>Test 1</title></head><body data-test="body-test"></body></html>';
@@ -21,13 +23,84 @@ describe('ServerManager', () => {
         <meta data-test="2" />
         <meta data-test="1" />
       </>,
-      'container-id',
+      containerId,
     );
 
     const result = ServerManager.inject(htmlStr, manager);
 
     expect(result).to.equal(
       '<html lang="en-EN" data-id="html-id"><head><meta charSet="UTF-8"/><title>Changed</title><meta data-test="1"/></head><body data-test="body-test" data-id="body-id"></body></html>',
+    );
+  });
+
+  it.each([
+    {
+      source: 'manager',
+      htmlStr:
+        '<html lang="en"><head><title>Original</title></head><body class="original"></body></html>',
+      tags: (
+        <>
+          {/* eslint-disable-next-line jsx-a11y/html-has-lang -- lang comes from the input HTML. */}
+          <html dir="rtl" className="x" />
+          <body className="y" />
+        </>
+      ),
+    },
+    {
+      source: 'input HTML',
+      htmlStr:
+        '<html lang="fr" dir="rtl" class="x"><head><title>Original</title></head><body class="y"></body></html>',
+      tags: <html lang="en" />,
+    },
+  ])(
+    'should merge root attributes from $source and inject meta into a single head',
+    ({ htmlStr, tags }) => {
+      const manager = new Manager();
+
+      manager.isServer = true;
+      manager.pushTags(tags, containerId);
+      manager.pushTags(
+        <>
+          <title>Changed</title>
+          <meta name="description" content="Inside the head" />
+        </>,
+        containerId,
+      );
+
+      const result = ServerManager.inject(htmlStr, manager);
+
+      expect(result.match(/<head/g)).to.have.lengthOf(1);
+      expect(result).to.equal(
+        '<html lang="en" dir="rtl" class="x"><head><title>Changed</title><meta name="description" content="Inside the head"/></head><body class="y"></body></html>',
+      );
+    },
+  );
+
+  it('should preserve React attribute serialization on root tags', () => {
+    const htmlStr =
+      '<html title="A &amp; &quot;B&quot; &lt;C&gt; &#x27;D&#x27;" style="margin-top:2px"><head>\n<title>Test</title></head><body class="original" hidden style="padding-top:3px"></body></html>';
+    const manager = new Manager();
+
+    manager.isServer = true;
+    manager.pushTags(
+      <>
+        <html lang="en" className="x" hidden draggable={false} />
+        <body
+          className="y"
+          hidden={false}
+          style={{ marginTop: 4, lineHeight: 1.5 }}
+          data-label={'A & "B" <C> \'D\''}
+          aria-hidden={false}
+        />
+      </>,
+      containerId,
+    );
+
+    const result = ServerManager.inject(htmlStr, manager);
+
+    expect(result.match(/<head/g)).to.have.lengthOf(1);
+    expect(result).to.equal(
+      '<html title="A &amp; &quot;B&quot; &lt;C&gt; &#x27;D&#x27;" style="margin-top:2px" lang="en" class="x" hidden="" draggable="false"><head><title>Test</title></head><body class="y" style="margin-top:4px;line-height:1.5" data-label="A &amp; &quot;B&quot; &lt;C&gt; &#x27;D&#x27;" aria-hidden="false"></body></html>',
     );
   });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -40,12 +40,17 @@ class ServerManager {
     const htmlMeta = ReactDOMServer.renderToString(
       [...meta.values()].map(({ element }) => element) as unknown as ReactElement,
     );
-    const [htmlTagWithProps] = ReactDOMServer.renderToString(
-      React.createElement('html', manager.getRootTagProps(html)),
-    ).split('</html>');
-    const [bodyTagWithProps] = ReactDOMServer.renderToString(
-      React.createElement('body', manager.getRootTagProps(body)),
-    ).split('</body>');
+    // Render a neutral element so React 19 does not insert document structure.
+    const [htmlTagWithProps] = ReactDOMServer.renderToStaticMarkup(
+      React.createElement('div', manager.getRootTagProps(html)),
+    )
+      .replace(/^<div/, '<html')
+      .split('</div>');
+    const [bodyTagWithProps] = ReactDOMServer.renderToStaticMarkup(
+      React.createElement('div', manager.getRootTagProps(body)),
+    )
+      .replace(/^<div/, '<body')
+      .split('</div>');
 
     return htmlStr
       .replace(/<head[^/].+?>?(?<meta>.+)<\/head>/s, `<head>${htmlMeta}</head>`)


### PR DESCRIPTION
## Goal

`MetaServer.inject` emits `<html lang="en"><head></head>` before the populated head when the host application runs React 19: React 19 renders a full document for a root `html` element, and the opening-tag extraction relied on React 18 output. Observed on https://vite-template.lomray.com/ (React 19.2.8).

## Changes

- `src/server/index.ts`: serialize the merged root props on a `div` with `renderToStaticMarkup`, rename the opening tag to `html` or `body`, drop the closing tag. Output for the same props is identical to what React 18 produced before.
- `__tests__/server/index.tsx`: regression cases for a single head, merged input and manager attributes on `html` and `body`, metadata placement, escaping, style objects and boolean attributes.
- `.github/workflows/pr-check.yml`: run the tests on the lockfile stack (React 18) and again after swapping in `react@19.2.8` and `react-dom@19.2.8`.

No public API change, no dependency change.

## Verification

- `npm ci --ignore-scripts`, `npm run lint:check`, `npm run ts:check`: clean.
- `npm test` on React 18.2.0: 8 tests pass. After `npm install --no-save --ignore-scripts react@19.2.8 react-dom@19.2.8`: 8 tests pass.
- `npm run build` on Node 20.18.3 (the repository's Node 20 line; the current Rollup plugin stack does not load on Node 22), packed `lib`, installed the archive into a copy of vite-template `prod` (React 19.2.8), `ssr-boost build` + `ssr-boost start`: `/` and `/details` each contain exactly one `<head>` and start with `<html lang="en">\n  <head><meta charSet="UTF-8"/>...`.
- A fresh `npm install react@19.2.8 react-dom@19.2.8 @lomray/react-head-manager@2.1.1` resolves without peer errors.

## Not run

- Browser rendering of the fixed markup (parsing of the previous output was already tolerated by browsers; the fix matters for crawlers and validators).
