### PR TITLE
fix: parse head markup with the server parser in worker bundles

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -73,6 +73,9 @@ jobs:
           npm pkg delete scripts.prepare
           npm run build -- --throw-warnings
 
+      - name: Test server worker bundle
+        run: npm run test:worker
+
   sonarcube:
     runs-on: ubuntu-latest
     needs: [check]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ manager.setTagsDefinitions({
 
 Explore [demo app](https://github.com/Lomray-Software/vite-template) to more understand.
 
+## Workers and edge rendering
+
+The `@lomray/react-head-manager/server` entry supports Cloudflare Workers and other non-DOM edge bundles, including Vite SSR with `ssr.target: 'webworker'`. `MetaServer.inject` and `MetaServer.getState` work without a `document` global or bundler aliases for `html-dom-parser`.
+
 ## Bundle size
 
 The browser build reads the existing head from the DOM and ships no HTML parser. `html-react-parser` is used only by the server helper.

--- a/__tests__/server/index.tsx
+++ b/__tests__/server/index.tsx
@@ -131,4 +131,28 @@ describe('ServerManager', () => {
       containers: ['custom', 'root'],
     });
   });
+
+  /**
+   * Preserve string-parser attribute casing even when a browser DOM is available.
+   */
+  it('should preserve custom element attribute casing and raw head content', () => {
+    const manager = new Manager();
+
+    manager.isServer = true;
+
+    const result = ServerManager.inject(
+      '<html lang="en"><head>\n<title>A &amp; B</title>' +
+        '<custom-meta buildId="Worker"></custom-meta>' +
+        '<script type="application/ld+json">{"value":"<tag>&"}</script>' +
+        '<style>.test > a { color: red; }</style></head><body></body></html>',
+      manager,
+    );
+
+    expect(result).to.equal(
+      '<html lang="en"><head><title>A &amp; B</title>' +
+        '<script type="application/ld+json">{"value":"<tag>&"}</script>' +
+        '<style>.test > a { color: red; }</style>' +
+        '<custom-meta buildId="Worker"></custom-meta></head><body></body></html>',
+    );
+  });
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint:format": "eslint --fix \"src/**/*.{ts,tsx,*.ts,*tsx}\"",
     "ts:check": "tsc --project ./tsconfig.json --skipLibCheck --noemit",
     "test": "vitest run",
+    "test:worker": "node scripts/test-worker.mjs",
     "test:package": "node scripts/test-package.mjs",
     "prepare": "husky install"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,6 +22,7 @@ export default {
   },
   external: [
     '@lomray/consistent-suspense',
+    'html-dom-parser/lib/server/html-to-dom',
     'html-react-parser',
   ],
   plugins: [

--- a/scripts/fixtures/server.mjs
+++ b/scripts/fixtures/server.mjs
@@ -1,0 +1,35 @@
+import { createElement } from 'react';
+import { Manager } from '../../lib/index.js';
+import MetaServer from '../../lib/server/index.js';
+
+/**
+ * Exercise parsed markup and rendered overrides through the built server entry.
+ */
+export const renderHead = (withOverrides = false) => {
+  const manager = new Manager();
+  const source =
+    '<html lang="en" style="margin-top:2px"><head>\n' +
+    '<meta charset="UTF-8"><title>Original &amp; title</title>' +
+    '<meta name="description" content="A &amp; &quot;B&quot;">' +
+    '<link rel="icon" href="/favicon.ico">' +
+    '<script type="application/ld+json">{"value":"<tag>&"}</script>' +
+    '<noscript>Enable JavaScript</noscript><style>.test > a { color: red; }</style>' +
+    '</head><body class="page" hidden><main>Unchanged &amp; body</main></body></html>';
+
+  if (withOverrides) {
+    manager.pushTags(
+      [
+        createElement('html', { lang: 'fr', dir: 'rtl' }),
+        createElement('body', { className: 'app', hidden: false }),
+        createElement('title', null, 'Worker & Node'),
+        createElement('meta', { name: 'description', content: 'Updated & description' }),
+      ],
+      'app',
+    );
+  }
+
+  const html = MetaServer.inject(source, manager);
+  const state = MetaServer.getState(manager);
+
+  return { isServer: manager.isServer, html, state };
+};

--- a/scripts/test-worker.mjs
+++ b/scripts/test-worker.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { runInNewContext } from 'node:vm';
+import { build } from 'esbuild';
+import { renderHead } from './fixtures/server.mjs';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const expected = [renderHead(), renderHead(true)];
+
+/**
+ * Run with Worker web APIs and release any message ports opened by React.
+ */
+const runWithoutDOM = (bundle) => {
+  const channels = [];
+
+  /**
+   * Track browser messaging resources so the check can exit after rendering.
+   */
+  function createMessageChannel() {
+    const channel = new MessageChannel();
+
+    channels.push(channel);
+
+    return channel;
+  }
+
+  const context = { atob, TextEncoder, ReadableStream, MessageChannel: createMessageChannel };
+
+  try {
+    // The evaluated code is this repository's own esbuild output, not external input.
+    const result = runInNewContext(`${bundle}\nserverResult;`, context, { timeout: 5000 }); // NOSONAR
+
+    for (const name of ['document', 'window', 'DOMParser', 'process', 'Buffer']) {
+      assert.equal(runInNewContext(`typeof ${name}`, context), 'undefined'); // NOSONAR
+    }
+
+    return JSON.parse(result);
+  } finally {
+    for (const { port1, port2 } of channels) {
+      port1.close();
+      port2.close();
+    }
+  }
+};
+
+for (const { isServer, html, state } of expected) {
+  assert.equal(isServer, true);
+  assert.match(html, /<meta charSet="UTF-8"\/>/);
+  assert.match(html, /<script type="application\/ld\+json">{"value":"<tag>&"}<\/script>/);
+  assert.match(html, /<style>\.test > a { color: red; }<\/style>/);
+  assert.match(html, /<main>Unchanged &amp; body<\/main>/);
+  assert.deepEqual(state.html[0], [
+    'root',
+    { props: { lang: 'en', style: { marginTop: '2px' } }, order: 1 },
+  ]);
+  assert.deepEqual(state.body[0], [
+    'root',
+    { props: { className: 'page', hidden: true }, order: 1 },
+  ]);
+}
+
+assert.match(expected[0].html, /<title>Original &amp; title<\/title>/);
+assert.match(expected[1].html, /<title>Worker &amp; Node<\/title>/);
+assert.match(expected[1].html, /<html lang="fr" style="margin-top:2px" dir="rtl">/);
+assert.match(expected[1].html, /<body class="app">/);
+assert.deepEqual(expected[1].state.containers, ['app', 'root']);
+console.info('[worker] Node: inject() and getState() passed for parsed markup and overrides.');
+
+for (const conditions of [undefined, ['worker'], ['workerd'], ['worker', 'workerd']]) {
+  const label = conditions?.join(',') ?? 'default';
+  const { outputFiles, metafile } = await build({
+    absWorkingDir: root,
+    stdin: {
+      contents:
+        "import { renderHead } from './scripts/fixtures/server.mjs';" +
+        'globalThis.serverResult = JSON.stringify([renderHead(), renderHead(true)]);',
+      resolveDir: root,
+      sourcefile: 'worker-check.mjs',
+    },
+    bundle: true,
+    platform: 'browser',
+    conditions,
+    format: 'iife',
+    write: false,
+    metafile: true,
+  });
+  const [{ text: bundle }] = outputFiles;
+  const inputs = Object.keys(metafile.inputs).join('\n');
+
+  assert.deepEqual(runWithoutDOM(bundle), expected);
+  assert.doesNotMatch(
+    inputs,
+    /html-dom-parser\/(?:lib|esm)\/index\./,
+    'The server bundle must bypass the environment-dependent parser entry.',
+  );
+  assert.doesNotMatch(
+    inputs,
+    /html-dom-parser\/(?:lib|esm)\/client\//,
+    'The server bundle must exclude the DOM parser.',
+  );
+  console.info(`[worker] platform=browser conditions=${label}: DOM-less output matches Node.`);
+}
+
+console.info('[worker] All checks passed; no aliases or DOM parser.');

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,7 @@
 // noinspection HtmlRequiredTitleElement
 
-import htmlParser from 'html-react-parser';
+import htmlToDOM from 'html-dom-parser/lib/server/html-to-dom';
+import domToReact from 'html-react-parser/lib/dom-to-react';
 import type { ReactElement } from 'react';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
@@ -11,6 +12,12 @@ interface IMetaManagerState {
   body: [string, Record<string, any>][];
   containers: string[];
 }
+
+/**
+ * Parse markup without a DOM while preserving React attribute conversion.
+ */
+const htmlParser = (html: string): ReturnType<typeof domToReact> =>
+  domToReact(htmlToDOM(html, { lowerCaseAttributeNames: false }));
 
 /**
  * Helpers for server side


### PR DESCRIPTION
## Summary
- The server entry parses head markup through `html-dom-parser`'s string parser and `html-react-parser`'s DOM-to-React step explicitly, so bundles built for `browser`/`worker`/`workerd` conditions (Cloudflare Workers, Vite SSR with `ssr.target: 'webworker'`) no longer need an alias and never touch `document`. Node output, attribute casing, entities and raw script/style content are unchanged (new jsdom regression).
- `npm run test:worker` bundles the built server entry with esbuild for the browser platform and the worker conditions, runs `inject`/`getState` without a DOM and compares with Node; wired into PR CI after the build. README documents Workers/edge support.

## Test plan
- [x] lint, types, 37 tests, build, `test:worker` (default, `worker`, `workerd`, combined conditions)
- [x] browser build output unchanged
