### PR TITLE
chore: drop the deprecated husky shim from the git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install commitlint -g commitlint.config.js --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
## Summary
- Removes the husky v8 shim lines (`#!/bin/sh` + `. husky.sh`) from the pre-commit and commit-msg hooks; husky 9 prints a deprecation warning for them and drops support in v10.

## Test plan
- [x] A local commit with the hooks installed still runs lint-staged and commitlint, without the deprecation warning
- [ ] PR check
